### PR TITLE
Scrapped Pull Request. (Rept)

### DIFF
--- a/BreakinIn/MatchmakerServer.cs
+++ b/BreakinIn/MatchmakerServer.cs
@@ -27,6 +27,7 @@ namespace BreakinIn
                 { "sele", typeof(SeleIn) }, //gets info for the current server
                 { "user", typeof(UserIn) }, //get my user info
                 { "onln", typeof(OnlnIn) }, //search for a user's info
+				{ "rept", typeof(ReptIn) }, //report user
                 { "addr", typeof(Addr) }, //the client tells us their IP and port (ephemeral). The IP is usually wrong.
 
                 { "chal", typeof(Chal) }, //enter challenge mode

--- a/BreakinIn/MatchmakerServer.cs
+++ b/BreakinIn/MatchmakerServer.cs
@@ -27,7 +27,7 @@ namespace BreakinIn
                 { "sele", typeof(SeleIn) }, //gets info for the current server
                 { "user", typeof(UserIn) }, //get my user info
                 { "onln", typeof(OnlnIn) }, //search for a user's info
-				{ "rept", typeof(ReptIn) }, //report user
+		{ "rept", typeof(ReptIn) }, //report user
                 { "addr", typeof(Addr) }, //the client tells us their IP and port (ephemeral). The IP is usually wrong.
 
                 { "chal", typeof(Chal) }, //enter challenge mode

--- a/BreakinIn/MatchmakerServer.cs
+++ b/BreakinIn/MatchmakerServer.cs
@@ -27,7 +27,7 @@ namespace BreakinIn
                 { "sele", typeof(SeleIn) }, //gets info for the current server
                 { "user", typeof(UserIn) }, //get my user info
                 { "onln", typeof(OnlnIn) }, //search for a user's info
-		{ "rept", typeof(ReptIn) }, //report user
+                { "rept", typeof(ReptIn) }, //report user
                 { "addr", typeof(Addr) }, //the client tells us their IP and port (ephemeral). The IP is usually wrong.
 
                 { "chal", typeof(Chal) }, //enter challenge mode
@@ -121,7 +121,7 @@ namespace BreakinIn
             }
 
             var personas = new string[4];
-            for (int i=0; i<user.Personas.Count; i++)
+            for (int i = 0; i < user.Personas.Count; i++)
             {
                 personas[i] = user.Personas[i];
             }

--- a/BreakinIn/Messages/ReptIn.cs
+++ b/BreakinIn/Messages/ReptIn.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BreakinIn.Messages
+{
+    public class ReptIn : AbstractMessage
+    {
+        public override string _Name { get => "rept"; }
+
+        public string PERS { get; set; }
+        public string PROD { get; set; }
+        public string LANG { get; set; }
+		
+		public override void Process(AbstractEAServer context, EAClient client)
+		{
+			var mc = context as MatchmakerServer;
+            if (mc == null) return;
+			
+			var PlayerReportingPlayer = new ReptOut()
+            {
+                PERS = PERS,
+            };
+
+            var user = client.User;
+            if (user == null) return;
+
+            if (user.PersonaName == PERS)
+            {
+                Console.WriteLine(user.PersonaName + " attempted to report themselves, which is not allowed.");
+                client.SendMessage(new ReportingSelf());
+            }
+            else
+            {
+                Console.WriteLine(user.PersonaName + " has reported " + PERS + ". Both players are currently in " + user.CurrentRoom.Name.ToString() + ".");
+                client.SendMessage(PlayerReportingPlayer);
+            }
+		}		
+    }
+    public class ReportingSelf : AbstractMessage
+    {
+        public override string _Name { get => "reptself"; }
+    }
+
+    public class ReportingDisabled : AbstractMessage
+    {
+        public override string _Name { get => "reptdisa"; }
+    }
+
+    public class ReportedUserHasntSpokenYet : AbstractMessage
+    {
+        public override string _Name { get => "reptwolf"; }
+    }
+}

--- a/BreakinIn/Messages/ReptIn.cs
+++ b/BreakinIn/Messages/ReptIn.cs
@@ -11,19 +11,21 @@ namespace BreakinIn.Messages
         public string PERS { get; set; }
         public string PROD { get; set; }
         public string LANG { get; set; }
-		
-		public override void Process(AbstractEAServer context, EAClient client)
-		{
-			var mc = context as MatchmakerServer;
+
+        public override void Process(AbstractEAServer context, EAClient client)
+        {
+            var mc = context as MatchmakerServer;
             if (mc == null) return;
-			
-			var PlayerReportingPlayer = new ReptOut()
+
+            var PlayerReportingPlayer = new ReptOut()
             {
                 PERS = PERS,
             };
 
             var user = client.User;
             if (user == null) return;
+
+
 
             if (user.PersonaName == PERS)
             {
@@ -32,10 +34,20 @@ namespace BreakinIn.Messages
             }
             else
             {
-                Console.WriteLine(user.PersonaName + " has reported " + PERS + ". Both players are currently in " + user.CurrentRoom.Name.ToString() + ".");
-                client.SendMessage(PlayerReportingPlayer);
+                if (user.CurrentRoom.Name.ToString() == null)
+                {
+                    Console.WriteLine(user.PersonaName + " has reported " + PERS + ". Both players seem to be in a certain room, but it doesn't have a name.");
+                    client.SendMessage(PlayerReportingPlayer);
+                    return;
+                }
+                else
+                {
+                    Console.WriteLine(user.PersonaName + " has reported " + PERS + ". The report has come from " + user.CurrentRoom.Name.ToString() + ".");
+                    client.SendMessage(PlayerReportingPlayer);
+                    return;
+                }
             }
-		}		
+        }
     }
     public class ReportingSelf : AbstractMessage
     {

--- a/BreakinIn/Messages/ReptIn.cs
+++ b/BreakinIn/Messages/ReptIn.cs
@@ -25,30 +25,28 @@ namespace BreakinIn.Messages
             var user = client.User;
             if (user == null) return;
 
-
+            var ReportedPlayer = mc.Users.GetUserByPersonaName(PERS);
+            if (ReportedPlayer == null) return;
 
             if (user.PersonaName == PERS)
             {
                 Console.WriteLine(user.PersonaName + " attempted to report themselves, which is not allowed.");
                 client.SendMessage(new ReportingSelf());
             }
-            else
+            else if (user.CurrentRoom == ReportedPlayer.CurrentRoom)
             {
-                if (user.CurrentRoom.Name.ToString() == null)
-                {
-                    Console.WriteLine(user.PersonaName + " has reported " + PERS + ". Both players seem to be in a certain room, but it doesn't have a name.");
-                    client.SendMessage(PlayerReportingPlayer);
-                    return;
-                }
-                else
-                {
-                    Console.WriteLine(user.PersonaName + " has reported " + PERS + ". The report has come from " + user.CurrentRoom.Name.ToString() + ".");
-                    client.SendMessage(PlayerReportingPlayer);
-                    return;
-                }
+                Console.WriteLine(user.PersonaName + " has reported " + PERS + " for inappropriate behaviour. Both players are currently in " + user.CurrentRoom.Name + ".");
+                client.SendMessage(PlayerReportingPlayer);
+                return;
+            }
+            else if (user.CurrentRoom != ReportedPlayer.CurrentRoom)
+            {
+                Console.WriteLine(user.PersonaName + " has reported " + PERS + ", but it appears that " + PERS + " left the room while the report was being made... " + PERS + " was previously in " + user.CurrentRoom.Name + ", while " + user.PersonaName + " should still be in that room.");
+                client.SendMessage(new ReportedUserHasntSpokenYetOrWasFalselyReported());
             }
         }
     }
+
     public class ReportingSelf : AbstractMessage
     {
         public override string _Name { get => "reptself"; }
@@ -59,7 +57,7 @@ namespace BreakinIn.Messages
         public override string _Name { get => "reptdisa"; }
     }
 
-    public class ReportedUserHasntSpokenYet : AbstractMessage
+    public class ReportedUserHasntSpokenYetOrWasFalselyReported : AbstractMessage
     {
         public override string _Name { get => "reptwolf"; }
     }

--- a/BreakinIn/Messages/ReptOut.cs
+++ b/BreakinIn/Messages/ReptOut.cs
@@ -7,7 +7,7 @@ namespace BreakinIn.Messages
     public class ReptOut : AbstractMessage
     {
         public override string _Name { get => "rept"; }
-		
-		public string PERS { get; set; }
-	}
+
+        public string PERS { get; set; }
+    }
 }

--- a/BreakinIn/Messages/ReptOut.cs
+++ b/BreakinIn/Messages/ReptOut.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BreakinIn.Messages
+{
+    public class ReptOut : AbstractMessage
+    {
+        public override string _Name { get => "rept"; }
+		
+		public string PERS { get; set; }
+	}
+}


### PR DESCRIPTION
Add a new message type that previously was unexpected and also ignored by the server.
Rept - Report a player while in the Matchmaker (Chatroom) lobby.

Add 3 error types to Rept.
Wolf = Reported user hasn't said anything in chat yet. (Displays in game as: "False report against user." Currently unused as there's no reliable way to check if a user has sent a message without adding chat log functionality on the server side. Included anyway for consistency's sake.)

Disa = Report feature is disabled. (self-explanatory, also unused as it's not needed, but included in the code anyway for consistency's sake.)

Self = Cannot report yourself. (self-explanatory, used for when reporting yourself.)