### PR TITLE
Find Sim Fixed & Europe/Japan Version Support

### DIFF
--- a/BreakinIn/Messages/OnlnIn.cs
+++ b/BreakinIn/Messages/OnlnIn.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using BreakinIn.Model;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -9,7 +10,6 @@ namespace BreakinIn.Messages
         public override string _Name { get => "onln"; }
 
         public string PERS { get; set; }
-        public string ROOM { get; set; } = "Room-A";
 
         public override void Process(AbstractEAServer context, EAClient client)
         {
@@ -19,18 +19,46 @@ namespace BreakinIn.Messages
             var user = client.User;
             if (user == null) return;
 
-            var Room = user.CurrentRoom;
-
             var info = user.GetInfo();
-            
             client.SendMessage(info);
-            client.SendMessage(this);
-            //client.SendMessage(new OnlnImst());
-        }
-    }
 
-    class OnlnImst : AbstractMessage
-    {
-        public override string _Name { get => "onlnimst"; }
+            var OtherPlayer = mc.Users.GetUserByPersonaName(PERS);
+
+
+            if (OtherPlayer == null)
+            {
+                client.SendMessage(new OnlnOut());
+                return;
+            }
+
+            if (OtherPlayer.PersonaName == user.PersonaName)
+            {
+                //There doesn't seem to be any error types or messages for searching for yourself.
+                client.SendMessage(new OnlnOut()
+                {
+                    N = user.PersonaName,
+                });
+                return;
+            }
+            if (OtherPlayer.CurrentRoom != null)
+            {
+                client.SendMessage(new OnlnOut()
+                {
+                    //Other player is online and are in a room.
+                    N = OtherPlayer.PersonaName,
+                    RM = OtherPlayer.CurrentRoom.Name,
+                });
+                return;
+            }
+            else if (OtherPlayer.CurrentRoom == null)
+            {
+                client.SendMessage(new OnlnOut()
+                {
+                    //Other player isn't in a room, but they are online in the main lobby.
+                    N = OtherPlayer.PersonaName,
+                });
+                return;
+            }
+        }
     }
 }

--- a/BreakinIn/Messages/OnlnOut.cs
+++ b/BreakinIn/Messages/OnlnOut.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BreakinIn.Messages
+{
+    public class OnlnOut : AbstractMessage
+    {
+        public override string _Name { get => "onln"; }
+
+        public string N { get; set; }
+        public string RM { get; set; }
+    }
+}
+

--- a/BreakinIn/TSBOServer.cs
+++ b/BreakinIn/TSBOServer.cs
@@ -18,15 +18,39 @@ namespace BreakinIn
             try
             {
                 Redirector = new RedirectorServer(11100, addr, 10901);
-                Console.WriteLine("Redirector: OK!");
+                Console.WriteLine("RedirectorUS: OK!");
             }
             catch (Exception e)
             {
-                Console.WriteLine("Redirector: Failed to start! Exception:");
+                Console.WriteLine("RedirectorUS: Failed to start! Exception:");
                 Console.WriteLine(e.ToString());
                 return false;
             }
-
+			
+			try
+            {
+                Redirector = new RedirectorServer(11140, addr, 10901);
+                Console.WriteLine("RedirectorEU: OK!");
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("RedirectorEU: Failed to start! Exception:");
+                Console.WriteLine(e.ToString());
+                return false;
+            }
+			
+			            try
+            {
+                Redirector = new RedirectorServer(11110, addr, 10901);
+                Console.WriteLine("RedirectorJP: OK!");
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("RedirectorJP: Failed to start! Exception:");
+                Console.WriteLine(e.ToString());
+                return false;
+            }
+			
             try
             {
                 Matchmaker = new MatchmakerServer(10901);


### PR DESCRIPTION
Added additional redirects for the European and Japanese versions.

The Korean version apparently has online as well, but without that version of the game to test it out, I can't add it in right now.

A word of caution regarding JP: Japanese Hiragana and Katakana characters do not show up in the American and European versions of the game for obvious reasons and will be displayed as blank, although the chat message will still be posted and the player's name will still be visible.

English characters will display as normal however, with the font the Japanese version uses.

Gameplay should not be affected by the different regional versions.